### PR TITLE
feat: Add GitHub Actions workflow for automated training

### DIFF
--- a/.github/workflows/train-sheikh.yml
+++ b/.github/workflows/train-sheikh.yml
@@ -1,0 +1,35 @@
+name: Train Sheikh Model
+
+on:
+  workflow_dispatch:  # Manual trigger
+  push:
+    branches:
+      - main
+
+jobs:
+  train:
+    runs-on: ubuntu-latest
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9' # Matching the CI file
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run Training Script
+        run: |
+          python train_sheikh.py \
+            --model_name "meta-llama/Meta-Llama-3-8B" \
+            --dataset_name "gaia-benchmark/GAIA" \
+            --output_dir "./sheikh-coder-finetuned" \
+            --push_to_hub \
+            --hub_model_id "likhonsheikh/sheikh-coder"

--- a/train_sheikh.py
+++ b/train_sheikh.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import trainer
 
 def main():
@@ -22,8 +23,8 @@ def main():
     parser.add_argument(
         "--hf_token",
         type=str,
-        required=True,
-        help="The Hugging Face API token for accessing gated models and datasets."
+        default=None,
+        help="The Hugging Face API token. If not provided, it will be read from the HF_TOKEN environment variable."
     )
     parser.add_argument(
         "--output_dir",
@@ -44,6 +45,18 @@ def main():
     )
 
     args = parser.parse_args()
+
+    # Prioritize token from argument, then environment variable
+    if args.hf_token:
+        token = args.hf_token
+    else:
+        token = os.getenv("HF_TOKEN")
+
+    if not token:
+        raise ValueError("Hugging Face token not found. Pass it with --hf_token or set the HF_TOKEN environment variable.")
+
+    # Assign the resolved token back to args
+    args.hf_token = token
 
     print("Training script started.")
     trainer.run(args)


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automate the model training and deployment pipeline.

Changes include:
- Renamed `run_training.py` to `train_sheikh.py` for clarity in the context of the new workflow.
- Updated `train_sheikh.py` to read the Hugging Face token from the `HF_TOKEN` environment variable, allowing it to be used securely in GitHub Actions.
- Added a new workflow file at `.github/workflows/train-sheikh.yml` that triggers on pushes to main or manually, and runs the end-to-end training and deployment process.