### PR TITLE
chore: Add debug step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.9'
+    - name: List files in workspace
+      run: ls -l
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
This commit adds a debugging step to the `ci.yml` workflow to diagnose an issue where the `requirements.txt` file is not being found.

The new step runs `ls -l` to list the contents of the workspace before the dependency installation step, which will help verify if the repository checkout is working as expected.