### PR TITLE
chore: Add debug step to training workflow

### DIFF
--- a/.github/workflows/train-sheikh.yml
+++ b/.github/workflows/train-sheikh.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           python-version: '3.9' # Matching the CI file
 
+      - name: List files recursively
+        run: ls -lR
+
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This commit adds a debugging step to the `train-sheikh.yml` workflow to diagnose an issue where the `requirements.txt` file is not being found.

The new step runs `ls -lR` to recursively list the contents of the workspace before the dependency installation step. This will help verify if the repository checkout is working as expected and where the files are located.